### PR TITLE
Consitent import notation:

### DIFF
--- a/ppm/components/main_window.py
+++ b/ppm/components/main_window.py
@@ -12,10 +12,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from PySide6.QtWidgets import QMainWindow, QWidget
+from PySide6 import QtWidgets
 
 
-class MainWindowComponent(QMainWindow):
+class MainWindowComponent(QtWidgets.QMainWindow):
     """
     A Class to handle the behaviour of the overall UI window
     """
@@ -36,7 +36,7 @@ class MainWindowComponent(QMainWindow):
         """
         raise NotImplementedError()
 
-    def load_ui(self) -> QWidget:
+    def load_ui(self) -> QtWidgets.QWidget:
         """
         Reads the UI XML file and converts it into a QT widget,
         and returns the widget

--- a/ppm/components/main_window.py
+++ b/ppm/components/main_window.py
@@ -31,7 +31,7 @@ class MainWindowComponent(QtWidgets.QMainWindow):
         super().__init__(*args, **kwargs)
 
     @property
-    def ui_component(self) -> QMainWindow:
+    def ui_component(self) -> QtWidgets.QMainWindow:
         raise NotImplementedError()
 
     def show(self):

--- a/ppm/main.py
+++ b/ppm/main.py
@@ -25,7 +25,7 @@ if os.getcwd() not in sys.path:
 import logging
 import logging.config
 
-from PySide6.QtWidgets import QApplication
+from PySide6 import QtWidgets
 
 from ppm.constants import LOG_FILENAME
 from ppm.main_window import MainWindow
@@ -47,7 +47,7 @@ def main():
 
 
 def initialise_ui(logger: logging.Logger):
-    app = QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
 
     logger.debug("Launching MainWindow")
     main_window = MainWindow()

--- a/ppm/main_window.py
+++ b/ppm/main_window.py
@@ -16,9 +16,7 @@ import logging
 import os
 import sys
 
-from PySide6.QtCore import QFile, QIODevice
-from PySide6.QtUiTools import QUiLoader
-from PySide6.QtWidgets import QWidget
+from PySide6 import QtCore, QtUiTools, QtWidgets
 
 import ppm.components as comp
 from ppm.constants import UI_FILENAME
@@ -57,7 +55,7 @@ class MainWindow(comp.MainWindowComponent):
         """
         self.ui_component.show()
 
-    def load_ui(self) -> QWidget:
+    def load_ui(self) -> QtWidgets.QWidget:
         """
         Reads the UI XML file and converts it into a QT widget,
         and returns the widget
@@ -68,15 +66,15 @@ class MainWindow(comp.MainWindowComponent):
         """
         # Load in the 'form.ui' file where the ui layout is defined
         path = os.path.join(os.path.dirname(__file__), UI_FILENAME)
-        ui_file = QFile(path)
+        ui_file = QtCore.QFile(path)
 
-        if not ui_file.open(QIODevice.ReadOnly):
+        if not ui_file.open(QtCore.QIODevice.ReadOnly):
             logger.error(f"Cannot open {UI_FILENAME}: {ui_file.errorString()}")
             sys.exit(-1)
 
         # Load the file using the QT UI loader class and return the
         # ui widget representing the layout
-        loader = QUiLoader()
+        loader = QtUiTools.QUiLoader()
         ui_window = loader.load(ui_file)
         ui_file.close()
         if not ui_window:


### PR DESCRIPTION
Change the importing notation of `PySide6` modules to import the the
top-level module, and then to access the submodules via dot notation,
rather than importing the classes directly.

This makes it more clear in the code where Qt classes are coming from.
